### PR TITLE
remove the reference of sub-package's image in test-texture.mtl

### DIFF
--- a/assets/cases/test-build/test-texture.mtl
+++ b/assets/cases/test-build/test-texture.mtl
@@ -25,12 +25,12 @@
   ],
   "_props": [
     {
+      "normalStrenth": 0,
       "mainTexture": {
         "__uuid__": "c32b5341-90fa-4e43-a906-b7eabefaafbd@6c48a"
-      },
-      "normalMap": {
-        "__uuid__": "fb4a237f-12a3-4133-b5f5-3f04173467b7@6c48a"
       }
-    }
+    },
+    {},
+    {}
   ]
 }

--- a/assets/cases/test-build/test-texture.mtl
+++ b/assets/cases/test-build/test-texture.mtl
@@ -29,8 +29,6 @@
       "mainTexture": {
         "__uuid__": "c32b5341-90fa-4e43-a906-b7eabefaafbd@6c48a"
       }
-    },
-    {},
-    {}
+    }
   ]
 }


### PR DESCRIPTION
移除 test-texture.mtl 材质资源对子包图片的引用 