### PR TITLE
Revert "Fix the crash of render ui to sprite frame scene on ios. (#493)"

### DIFF
--- a/assets/cases/rendertexture/duck.mtl
+++ b/assets/cases/rendertexture/duck.mtl
@@ -4,31 +4,41 @@
   "_objFlags": 0,
   "_native": "",
   "_effectAsset": {
-    "__uuid__": "1baf0fc9-befa-459c-8bdd-af1a450a0319",
-    "__expectedType__": "cc.EffectAsset"
+    "__uuid__": "1baf0fc9-befa-459c-8bdd-af1a450a0319"
   },
-  "_techIdx": "1",
+  "_techIdx": 0,
   "_defines": [
-    {},
-    {},
-    {}
+    {
+      "USE_ALBEDO_MAP": true,
+      "OCCLUSION_CHANNEL": "b",
+      "ROUGHNESS_CHANNEL": "r",
+      "METALLIC_CHANNEL": "g"
+    }
   ],
   "_states": [
     {
-      "rasterizerState": {},
-      "depthStencilState": {},
       "blendState": {
         "targets": [
           {}
         ]
-      }
-    },
-    {},
-    {}
+      },
+      "depthStencilState": {},
+      "rasterizerState": {}
+    }
   ],
   "_props": [
-    {},
-    {},
-    {}
+    {
+      "albedoScale": {
+        "__type__": "cc.Vec4",
+        "x": 8,
+        "y": 8,
+        "z": 8,
+        "w": 0
+      },
+      "alphaThreshold": 0,
+      "mainTexture": {
+        "__uuid__": "f0e9af09-f905-4e5b-aea5-f31cd19ca7e5@6c48a"
+      }
+    }
   ]
 }


### PR DESCRIPTION
This reverts commit 0922614744cd688c335eafc91dfc905e5fa89506.

直接修改为 透明队列会有嘴裂和纹理丢失的问题，revert 这个 commit，延迟管线的问题重新解决