### PR TITLE
ignore mouse move event after mouse up

### DIFF
--- a/assets/cases/base/containerStragety.ts.meta
+++ b/assets/cases/base/containerStragety.ts.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "4.0.22",
+  "ver": "4.0.23",
   "importer": "typescript",
   "imported": true,
   "uuid": "f1bbb46b-c8e2-4db1-b453-b36fcd8cfd06",

--- a/assets/cases/base/containerStrategy.scene
+++ b/assets/cases/base/containerStrategy.scene
@@ -1793,7 +1793,7 @@
     "__prefab": null,
     "_contentSize": {
       "__type__": "cc.Size",
-      "width": 825.02,
+      "width": 950.91,
       "height": 97.8
     },
     "_anchorPoint": {
@@ -1823,14 +1823,14 @@
       "b": 223,
       "a": 255
     },
-    "_string": "测试方法：\n- 可以通过 chrome 调试的真机模拟，来测试窗口拖动，开启真机模拟后需要刷新页面\n- 或者通过 PC 浏览器测试 Web-Mobile 平台也可以验证",
+    "_string": "测试方法：\n- 可以通过浏览器预览，chrome 调试的真机模拟，来测试窗口拖动，开启真机模拟后需要刷新页面，见下图\n- 或者通过 PC 浏览器测试 Web-Mobile 平台也可以验证",
     "_horizontalAlign": 0,
     "_verticalAlign": 1,
-    "_actualFontSize": 22,
+    "_actualFontSize": 20,
     "_fontSize": 22,
     "_fontFamily": "Arial",
     "_lineHeight": 30,
-    "_overflow": 0,
+    "_overflow": 2,
     "_enableWrapText": true,
     "_font": null,
     "_isSystemFontUsed": true,
@@ -2223,6 +2223,9 @@
     },
     "fog": {
       "__id__": 77
+    },
+    "octree": {
+      "__id__": 78
     }
   },
   {
@@ -2339,5 +2342,22 @@
     "_fogTop": 1.5,
     "_fogRange": 1.2,
     "_accurate": false
+  },
+  {
+    "__type__": "cc.OctreeInfo",
+    "_enabled": false,
+    "_minPos": {
+      "__type__": "cc.Vec3",
+      "x": -1024,
+      "y": -1024,
+      "z": -1024
+    },
+    "_maxPos": {
+      "__type__": "cc.Vec3",
+      "x": 1024,
+      "y": 1024,
+      "z": 1024
+    },
+    "_depth": 8
   }
 ]

--- a/assets/cases/event/system-event/mouse-event.ts
+++ b/assets/cases/event/system-event/mouse-event.ts
@@ -58,6 +58,7 @@ export class systemEventPC extends Component {
             }
             this._timeoutId = setTimeout(() => {
                 this._ignoreMoveEvent = false;
+                this._timeoutId = -1
             }, 100);
         }
         this.labelShow.string = `MOUSE_UP: ${event.getLocation()}`;

--- a/assets/cases/event/system-event/pointer-swallow.scene
+++ b/assets/cases/event/system-event/pointer-swallow.scene
@@ -534,7 +534,7 @@
       "b": 148,
       "a": 255
     },
-    "_string": "预期：\n分别点击两个按钮，然后上下滑动\n- 左侧红色的按钮，会阻塞底下 ScrollView 的滑动\n- 右侧绿色的按钮，不会阻塞底下 ScrollView 的滑动",
+    "_string": "预期：\n单手指分别点击两个按钮，然后上下滑动\n- 左侧红色的按钮，会阻塞底下 ScrollView 的滑动\n- 右侧绿色的按钮，不会阻塞底下 ScrollView 的滑动",
     "_horizontalAlign": 0,
     "_verticalAlign": 1,
     "_actualFontSize": 20,

--- a/assets/cases/event/system-event/pointer-swallow.scene
+++ b/assets/cases/event/system-event/pointer-swallow.scene
@@ -534,7 +534,7 @@
       "b": 148,
       "a": 255
     },
-    "_string": "预期：\n鼠标点击两个按钮\n- 左侧红色的按钮，会阻塞底下 ScrollView 的滑动\n- 右侧绿色的按钮，不会阻塞底下 ScrollView 的滑动",
+    "_string": "预期：\n分别点击两个按钮，然后上下滑动\n- 左侧红色的按钮，会阻塞底下 ScrollView 的滑动\n- 右侧绿色的按钮，不会阻塞底下 ScrollView 的滑动",
     "_horizontalAlign": 0,
     "_verticalAlign": 1,
     "_actualFontSize": 20,


### PR DESCRIPTION
resolve https://github.com/cocos-creator/3d-tasks/issues/9031
resolve https://github.com/cocos-creator/3d-tasks/issues/10159

changeLog:
- 完善 containerStrategy 测试例说明
- 完善 pointer-swallow 测试例
- mouse up 后的 100 ms 内，忽略 mouse move 事件

这是 windows chrome 上的一个 bug，mouse up 之后，必定会派发一个 mouse move 事件，导致渲染的时候 mouse up 被 mouse move 覆盖了，看起来就像是没有触发 mouse up 一样