### PR TITLE
fix issue10203, change loadtips initialization when curtype===lasttype

### DIFF
--- a/assets/cases/scripting/asset_loading/PreloadAssets/PreloadAssets.ts
+++ b/assets/cases/scripting/asset_loading/PreloadAssets/PreloadAssets.ts
@@ -68,7 +68,7 @@ export class PreloadAssets extends Component {
 
         this._curType = event.target.name.split('_')[1];
         if (this._lastType !== "" && this._curType === this._lastType) {
-            this.loadTips.string = ''
+            this.loadTips.string = this._curType + " Loading....";
             this._onShowResClick(event);
             return;
         }


### PR DESCRIPTION
Re:
https://github.com/cocos-creator/3d-tasks/issues/10203

Changelog:

- 修改点击响应函数，当上次选中的类型不为空且本次选中类型与上次选中相等时，将loadTips的字符串先赋值为this._curType + " Loading....";

**问题原因**
&emsp;&emsp;首次点击"播放Audio"按钮，会预加载音频。再次点击，按测试例代码逻辑，是先清空提示文字， 再去加载音频并更新提示文字为"播放音乐。"，当加载音频的过程存在延迟时，就会发生issue所描述的现象，也就是到音频加载完成之前，提示文字都是看不见的。