### PR TITLE
Default texture unit test@xianjie.cai

### DIFF
--- a/assets/cases/material/builtin-textures-test.ts
+++ b/assets/cases/material/builtin-textures-test.ts
@@ -209,19 +209,53 @@ export class BuiltinTexturesTest extends Component {
         });
         defaultRenderMatCanvas.setProperty('mainTexture', defaultTextureCanvas, 0);
 
-        this.nodeBlack.getComponent(MeshRenderer).material   = blackRenderMat;
-        this.nodeWhite.getComponent(MeshRenderer).material   = whiteRenderMat;
-        this.nodeGrey.getComponent(MeshRenderer).material    = greyRenderMat;
-        this.nodeEmpty.getComponent(MeshRenderer).material   = emptyRenderMat;
-        this.nodeNormal.getComponent(MeshRenderer).material  = normalRenderMat;
-        this.nodeDefault.getComponent(MeshRenderer).material = defaultRenderMat;
+        if (this.nodeBlack) {
+            this.nodeBlack.getComponent(MeshRenderer).material   = blackRenderMat;
+        }
 
-        this.nodeBlack1.getComponent(MeshRenderer).material   = blackRenderMatCanvas;
-        this.nodeWhite1.getComponent(MeshRenderer).material   = whiteRenderMatCanvas;
-        this.nodeGrey1.getComponent(MeshRenderer).material    = greyRenderMatCanvas;
-        this.nodeEmpty1.getComponent(MeshRenderer).material   = emptyRenderMatCanvas;
-        this.nodeNormal1.getComponent(MeshRenderer).material  = normalRenderMatCanvas;
-        this.nodeDefault1.getComponent(MeshRenderer).material = defaultRenderMatCanvas;
+        if (this.nodeWhite) {
+            this.nodeWhite.getComponent(MeshRenderer).material   = whiteRenderMat;
+        }
+
+        if (this.nodeGrey) {
+            this.nodeGrey.getComponent(MeshRenderer).material    = greyRenderMat;
+        }
+
+        if (this.nodeEmpty) {
+            this.nodeEmpty.getComponent(MeshRenderer).material   = emptyRenderMat;
+        }
+
+        if (this.nodeNormal) {
+            this.nodeNormal.getComponent(MeshRenderer).material  = normalRenderMat;
+        }
+
+        if (this.nodeDefault) {
+            this.nodeDefault.getComponent(MeshRenderer).material = defaultRenderMat;
+        }
+
+        if (this.nodeBlack1) {
+            this.nodeBlack1.getComponent(MeshRenderer).material   = blackRenderMatCanvas;
+        }
+
+        if (this.nodeWhite1) {
+            this.nodeWhite1.getComponent(MeshRenderer).material   = whiteRenderMatCanvas;
+        }
+
+        if (this.nodeGrey1) {
+            this.nodeGrey1.getComponent(MeshRenderer).material    = greyRenderMatCanvas;
+        }
+
+        if (this.nodeEmpty1) {
+            this.nodeEmpty1.getComponent(MeshRenderer).material   = emptyRenderMatCanvas;
+        }
+
+        if (this.nodeNormal1) {
+            this.nodeNormal1.getComponent(MeshRenderer).material  = normalRenderMatCanvas;
+        }
+
+        if (this.nodeDefault1) {
+            this.nodeDefault1.getComponent(MeshRenderer).material = defaultRenderMatCanvas;
+        }
 
         const defaultCubeTexture = builtinResMgr.get<TextureCube>("default-cube-texture");
         director.getScene().globals.skybox.envmap = defaultCubeTexture;

--- a/assets/cases/material/builtin-textures-test.ts
+++ b/assets/cases/material/builtin-textures-test.ts
@@ -1,0 +1,229 @@
+
+import { _decorator, Component, Node, Material, MeshRenderer, builtinResMgr, Texture2D, TextureCube, ImageAsset, director } from 'cc';
+const { ccclass, property } = _decorator;
+
+/**
+ * Predefined variables
+ * Name = BuiltinTexturesTest
+ * DateTime = Wed Dec 22 2021 18:14:42 GMT+0800 (中国标准时间)
+ * Author = Greg1129
+ * FileBasename = builtin-textures-test.ts
+ * FileBasenameNoExtension = builtin-textures-test
+ * URL = db://assets/cases/material/builtin-textures-test.ts
+ * ManualUrl = https://docs.cocos.com/creator/3.4/manual/en/
+ *
+ */
+ 
+@ccclass('BuiltinTexturesTest')
+export class BuiltinTexturesTest extends Component {
+    // [1]
+    // dummy = '';
+
+    // [2]
+    // @property
+    // serializableDummy = 0;
+    @property({type: Node})
+    public nodeBlack = null;
+
+    @property({type: Node})
+    public nodeWhite = null;
+
+    @property({type: Node})
+    public nodeGrey = null;
+
+    @property({type: Node})
+    public nodeEmpty = null;
+
+    @property({type: Node})
+    public nodeNormal = null;
+
+    @property({type: Node})
+    public nodeDefault = null;
+
+    @property({type: Node})
+    public nodeBlack1 = null;
+
+    @property({type: Node})
+    public nodeWhite1 = null;
+
+    @property({type: Node})
+    public nodeGrey1 = null;
+
+    @property({type: Node})
+    public nodeEmpty1 = null;
+
+    @property({type: Node})
+    public nodeNormal1 = null;
+
+    @property({type: Node})
+    public nodeDefault1 = null;
+
+    start () {
+        const blackTexture   = builtinResMgr.get<Texture2D>('black-texture');
+        const whiteTexture   = builtinResMgr.get<Texture2D>('white-texture');
+        const greyTexture    = builtinResMgr.get<Texture2D>('grey-texture');
+        const emptyTexture   = builtinResMgr.get<Texture2D>('empty-texture');
+        const normalTexture  = builtinResMgr.get<Texture2D>('normal-texture');
+        const defaultTexture = builtinResMgr.get<Texture2D>('default-texture');
+
+        const blackRenderMat = new Material();
+        blackRenderMat._uuid = "black";
+        blackRenderMat.initialize({
+            effectName: 'unlit',
+            defines: { USE_TEXTURE: true },
+        });
+        blackRenderMat.setProperty('mainTexture', blackTexture, 0);
+
+        const whiteRenderMat = new Material();
+        whiteRenderMat._uuid = "white";
+        whiteRenderMat.initialize({
+            effectName: 'unlit',
+            defines: { USE_TEXTURE: true },
+        });
+        whiteRenderMat.setProperty('mainTexture', whiteTexture, 0);
+
+        const greyRenderMat = new Material();
+        greyRenderMat._uuid = "grey";
+        greyRenderMat.initialize({
+            effectName: 'unlit',
+            defines: { USE_TEXTURE: true },
+        });
+        greyRenderMat.setProperty('mainTexture', greyTexture, 0);
+
+        const emptyRenderMat = new Material();
+        emptyRenderMat._uuid = "empty";
+        emptyRenderMat.initialize({
+            effectName: 'unlit',
+            defines: { USE_TEXTURE: true },
+        });
+        emptyRenderMat.setProperty('mainTexture', emptyTexture, 0);
+
+        const normalRenderMat = new Material();
+        normalRenderMat._uuid = "normal";
+        normalRenderMat.initialize({
+            effectName: 'unlit',
+            defines: { USE_TEXTURE: true },
+        });
+        normalRenderMat.setProperty('mainTexture', normalTexture, 0);
+
+        const defaultRenderMat = new Material();
+        defaultRenderMat._uuid = "default";
+        defaultRenderMat.initialize({
+            effectName: 'unlit',
+            defines: { USE_TEXTURE: true },
+        });
+        defaultRenderMat.setProperty('mainTexture', defaultTexture, 0);
+
+        // build from canvas
+        const canvas = document.createElement('canvas');
+        const context = canvas.getContext('2d')!;
+        const imgAsset = new ImageAsset(canvas);
+        const l = canvas.width = canvas.height = 2;
+
+        // black texture
+        context.fillStyle = '#000';
+        context.fillRect(0, 0, l, l);
+        const blackTextureCanvas = new Texture2D();
+        blackTextureCanvas.image = imgAsset;
+
+        // empty texture
+        context.fillStyle = 'rgba(0,0,0,0)';
+        context.fillRect(0, 0, l, l);
+        const emptyTextureCanvas = new Texture2D();
+        emptyTextureCanvas.image = imgAsset;
+
+        // grey texture
+        context.fillStyle = '#777777';
+        context.fillRect(0, 0, l, l);
+        const greyTextureCanvas = new Texture2D();
+        greyTextureCanvas.image = imgAsset;
+
+        // white texture
+        context.fillStyle = '#ffffff';
+        context.fillRect(0, 0, l, l);
+        const whiteTextureCanvas = new Texture2D();
+        whiteTextureCanvas.image = imgAsset;
+
+        // normal texture
+        context.fillStyle = '#7f7fff';
+        context.fillRect(0, 0, l, l);
+        const normalTextureCanvas = new Texture2D();
+        normalTextureCanvas.image = imgAsset;
+
+        // default texture
+        canvas.width = canvas.height = 16;
+        context.fillStyle = '#dddddd';
+        context.fillRect(0, 0, 16, 16);
+        context.fillStyle = '#555555';
+        context.fillRect(0, 0, 8, 8);
+        context.fillStyle = '#555555';
+        context.fillRect(8, 8, 8, 8);
+        const defaultTextureCanvas = new Texture2D();
+        defaultTextureCanvas.image = imgAsset;
+
+        const blackRenderMatCanvas = new Material();
+        blackRenderMatCanvas._uuid = "black1";
+        blackRenderMatCanvas.initialize({
+            effectName: 'unlit',
+            defines: { USE_TEXTURE: true },
+        });
+        blackRenderMatCanvas.setProperty('mainTexture', blackTextureCanvas, 0);
+
+        const whiteRenderMatCanvas = new Material();
+        whiteRenderMatCanvas._uuid = "white1";
+        whiteRenderMatCanvas.initialize({
+            effectName: 'unlit',
+            defines: { USE_TEXTURE: true },
+        });
+        whiteRenderMatCanvas.setProperty('mainTexture', whiteTextureCanvas, 0);
+
+        const greyRenderMatCanvas = new Material();
+        greyRenderMatCanvas._uuid = "grey1";
+        greyRenderMatCanvas.initialize({
+            effectName: 'unlit',
+            defines: { USE_TEXTURE: true },
+        });
+        greyRenderMatCanvas.setProperty('mainTexture', greyTextureCanvas, 0);
+
+        const emptyRenderMatCanvas = new Material();
+        emptyRenderMatCanvas._uuid = "empty1";
+        emptyRenderMatCanvas.initialize({
+            effectName: 'unlit',
+            defines: { USE_TEXTURE: true },
+        });
+        emptyRenderMatCanvas.setProperty('mainTexture', emptyTextureCanvas, 0);
+
+        const normalRenderMatCanvas = new Material();
+        normalRenderMatCanvas._uuid = "normal1";
+        normalRenderMatCanvas.initialize({
+            effectName: 'unlit',
+            defines: { USE_TEXTURE: true },
+        });
+        normalRenderMatCanvas.setProperty('mainTexture', normalTextureCanvas, 0);
+
+        const defaultRenderMatCanvas = new Material();
+        defaultRenderMatCanvas._uuid = "default1";
+        defaultRenderMatCanvas.initialize({
+            effectName: 'unlit',
+            defines: { USE_TEXTURE: true },
+        });
+        defaultRenderMatCanvas.setProperty('mainTexture', defaultTextureCanvas, 0);
+
+        this.nodeBlack.getComponent(MeshRenderer).material   = blackRenderMat;
+        this.nodeWhite.getComponent(MeshRenderer).material   = whiteRenderMat;
+        this.nodeGrey.getComponent(MeshRenderer).material    = greyRenderMat;
+        this.nodeEmpty.getComponent(MeshRenderer).material   = emptyRenderMat;
+        this.nodeNormal.getComponent(MeshRenderer).material  = normalRenderMat;
+        this.nodeDefault.getComponent(MeshRenderer).material = defaultRenderMat;
+
+        this.nodeBlack1.getComponent(MeshRenderer).material   = blackRenderMatCanvas;
+        this.nodeWhite1.getComponent(MeshRenderer).material   = whiteRenderMatCanvas;
+        this.nodeGrey1.getComponent(MeshRenderer).material    = greyRenderMatCanvas;
+        this.nodeEmpty1.getComponent(MeshRenderer).material   = emptyRenderMatCanvas;
+        this.nodeNormal1.getComponent(MeshRenderer).material  = normalRenderMatCanvas;
+        this.nodeDefault1.getComponent(MeshRenderer).material = defaultRenderMatCanvas;
+
+        const defaultCubeTexture = builtinResMgr.get<TextureCube>("default-cube-texture");
+        director.getScene().globals.skybox.envmap = defaultCubeTexture;
+    }
+}

--- a/assets/cases/material/builtin-textures-test.ts.meta
+++ b/assets/cases/material/builtin-textures-test.ts.meta
@@ -1,0 +1,9 @@
+{
+  "ver": "4.0.23",
+  "importer": "typescript",
+  "imported": true,
+  "uuid": "688f9613-d581-4f09-a5f6-fb082d648bfc",
+  "files": [],
+  "subMetas": {},
+  "userData": {}
+}

--- a/assets/cases/material/builtin-textures.scene
+++ b/assets/cases/material/builtin-textures.scene
@@ -1,0 +1,1517 @@
+[
+  {
+    "__type__": "cc.SceneAsset",
+    "_name": "",
+    "_objFlags": 0,
+    "_native": "",
+    "scene": {
+      "__id__": 1
+    }
+  },
+  {
+    "__type__": "cc.Scene",
+    "_name": "builtin-textures",
+    "_objFlags": 0,
+    "_parent": null,
+    "_children": [
+      {
+        "__id__": 2
+      },
+      {
+        "__id__": 5
+      },
+      {
+        "__id__": 7
+      }
+    ],
+    "_active": true,
+    "_components": [],
+    "_prefab": null,
+    "autoReleaseAssets": false,
+    "_globals": {
+      "__id__": 45
+    },
+    "_id": "786100e2-d117-43f2-a3fe-ea5d0298cffe"
+  },
+  {
+    "__type__": "cc.Node",
+    "_name": "Main Light",
+    "_objFlags": 0,
+    "_parent": {
+      "__id__": 1
+    },
+    "_children": [],
+    "_active": false,
+    "_components": [
+      {
+        "__id__": 3
+      }
+    ],
+    "_prefab": null,
+    "_lpos": {
+      "__type__": "cc.Vec3",
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "_lrot": {
+      "__type__": "cc.Quat",
+      "x": -0.24999999999999997,
+      "y": -0.24999999999999997,
+      "z": -0.06698729810778066,
+      "w": 0.9330127018922194
+    },
+    "_lscale": {
+      "__type__": "cc.Vec3",
+      "x": 1,
+      "y": 1,
+      "z": 1
+    },
+    "_layer": 1073741824,
+    "_euler": {
+      "__type__": "cc.Vec3",
+      "x": -30,
+      "y": -30,
+      "z": 0
+    },
+    "_id": "c0y6F5f+pAvI805TdmxIjx"
+  },
+  {
+    "__type__": "cc.DirectionalLight",
+    "_name": "",
+    "_objFlags": 0,
+    "node": {
+      "__id__": 2
+    },
+    "_enabled": true,
+    "__prefab": null,
+    "_color": {
+      "__type__": "cc.Color",
+      "r": 255,
+      "g": 255,
+      "b": 255,
+      "a": 255
+    },
+    "_useColorTemperature": false,
+    "_colorTemperature": 6550,
+    "_staticSettings": {
+      "__id__": 4
+    },
+    "_illuminanceHDR": 65000,
+    "_illuminance": 65000,
+    "_illuminanceLDR": 1.6927083333333335,
+    "_id": "597uMYCbhEtJQc0ffJlcgA"
+  },
+  {
+    "__type__": "cc.StaticLightSettings",
+    "_baked": false,
+    "_editorOnly": false,
+    "_bakeable": false,
+    "_castShadow": false
+  },
+  {
+    "__type__": "cc.Node",
+    "_name": "Main Camera",
+    "_objFlags": 0,
+    "_parent": {
+      "__id__": 1
+    },
+    "_children": [],
+    "_active": true,
+    "_components": [
+      {
+        "__id__": 6
+      }
+    ],
+    "_prefab": null,
+    "_lpos": {
+      "__type__": "cc.Vec3",
+      "x": -25,
+      "y": 40,
+      "z": 55
+    },
+    "_lrot": {
+      "__type__": "cc.Quat",
+      "x": -0.27781593346944056,
+      "y": -0.36497167621709875,
+      "z": -0.11507512748638377,
+      "w": 0.8811195706053617
+    },
+    "_lscale": {
+      "__type__": "cc.Vec3",
+      "x": 1,
+      "y": 1,
+      "z": 1
+    },
+    "_layer": 1073741824,
+    "_euler": {
+      "__type__": "cc.Vec3",
+      "x": -35,
+      "y": -45,
+      "z": 0
+    },
+    "_id": "c9DMICJLFO5IeO07EPon7U"
+  },
+  {
+    "__type__": "cc.Camera",
+    "_name": "",
+    "_objFlags": 0,
+    "node": {
+      "__id__": 5
+    },
+    "_enabled": true,
+    "__prefab": null,
+    "_projection": 1,
+    "_priority": 0,
+    "_fov": 45,
+    "_fovAxis": 0,
+    "_orthoHeight": 10,
+    "_near": 1,
+    "_far": 1000,
+    "_color": {
+      "__type__": "cc.Color",
+      "r": 51,
+      "g": 51,
+      "b": 51,
+      "a": 255
+    },
+    "_depth": 1,
+    "_stencil": 0,
+    "_clearFlags": 14,
+    "_rect": {
+      "__type__": "cc.Rect",
+      "x": 0,
+      "y": 0,
+      "width": 1,
+      "height": 1
+    },
+    "_aperture": 19,
+    "_shutter": 7,
+    "_iso": 0,
+    "_screenScale": 1,
+    "_visibility": 1822425087,
+    "_targetTexture": null,
+    "_id": "7dWQTpwS5LrIHnc1zAPUtf"
+  },
+  {
+    "__type__": "cc.Node",
+    "_name": "Node",
+    "_objFlags": 0,
+    "_parent": {
+      "__id__": 1
+    },
+    "_children": [
+      {
+        "__id__": 8
+      },
+      {
+        "__id__": 11
+      },
+      {
+        "__id__": 14
+      },
+      {
+        "__id__": 17
+      },
+      {
+        "__id__": 20
+      },
+      {
+        "__id__": 23
+      },
+      {
+        "__id__": 26
+      },
+      {
+        "__id__": 29
+      },
+      {
+        "__id__": 32
+      },
+      {
+        "__id__": 35
+      },
+      {
+        "__id__": 38
+      },
+      {
+        "__id__": 41
+      }
+    ],
+    "_active": true,
+    "_components": [
+      {
+        "__id__": 44
+      }
+    ],
+    "_prefab": null,
+    "_lpos": {
+      "__type__": "cc.Vec3",
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "_lrot": {
+      "__type__": "cc.Quat",
+      "x": 0,
+      "y": 0,
+      "z": 0,
+      "w": 1
+    },
+    "_lscale": {
+      "__type__": "cc.Vec3",
+      "x": 1,
+      "y": 1,
+      "z": 1
+    },
+    "_layer": 1073741824,
+    "_euler": {
+      "__type__": "cc.Vec3",
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "_id": "74QFPN8tlD44avY0fdHTTF"
+  },
+  {
+    "__type__": "cc.Node",
+    "_name": "Black",
+    "_objFlags": 0,
+    "_parent": {
+      "__id__": 7
+    },
+    "_children": [],
+    "_active": true,
+    "_components": [
+      {
+        "__id__": 9
+      }
+    ],
+    "_prefab": null,
+    "_lpos": {
+      "__type__": "cc.Vec3",
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "_lrot": {
+      "__type__": "cc.Quat",
+      "x": 0,
+      "y": 0,
+      "z": 0,
+      "w": 1
+    },
+    "_lscale": {
+      "__type__": "cc.Vec3",
+      "x": 10,
+      "y": 10,
+      "z": 10
+    },
+    "_layer": 1073741824,
+    "_euler": {
+      "__type__": "cc.Vec3",
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "_id": "3fP17zFplGo6rk88PctmTi"
+  },
+  {
+    "__type__": "cc.MeshRenderer",
+    "_name": "Cube<ModelComponent>",
+    "_objFlags": 0,
+    "node": {
+      "__id__": 8
+    },
+    "_enabled": true,
+    "__prefab": null,
+    "_materials": [
+      {
+        "__uuid__": "d3c7820c-2a98-4429-8bc7-b8453bc9ac41",
+        "__expectedType__": "cc.Material"
+      }
+    ],
+    "_visFlags": 0,
+    "lightmapSettings": {
+      "__id__": 10
+    },
+    "_mesh": {
+      "__uuid__": "1263d74c-8167-4928-91a6-4e2672411f47@a804a",
+      "__expectedType__": "cc.Mesh"
+    },
+    "_shadowCastingMode": 0,
+    "_shadowReceivingMode": 1,
+    "_enableMorph": true,
+    "_id": "72LrE72AJHyZFrZSQLgcHt"
+  },
+  {
+    "__type__": "cc.ModelLightmapSettings",
+    "texture": null,
+    "uvParam": {
+      "__type__": "cc.Vec4",
+      "x": 0,
+      "y": 0,
+      "z": 0,
+      "w": 0
+    },
+    "_bakeable": false,
+    "_castShadow": false,
+    "_receiveShadow": false,
+    "_recieveShadow": false,
+    "_lightmapSize": 64
+  },
+  {
+    "__type__": "cc.Node",
+    "_name": "BlackFromCanvas",
+    "_objFlags": 0,
+    "_parent": {
+      "__id__": 7
+    },
+    "_children": [],
+    "_active": true,
+    "_components": [
+      {
+        "__id__": 12
+      }
+    ],
+    "_prefab": null,
+    "_lpos": {
+      "__type__": "cc.Vec3",
+      "x": 15,
+      "y": 0,
+      "z": 0
+    },
+    "_lrot": {
+      "__type__": "cc.Quat",
+      "x": 0,
+      "y": 0,
+      "z": 0,
+      "w": 1
+    },
+    "_lscale": {
+      "__type__": "cc.Vec3",
+      "x": 10,
+      "y": 10,
+      "z": 10
+    },
+    "_layer": 1073741824,
+    "_euler": {
+      "__type__": "cc.Vec3",
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "_id": "0aChyzRxFLs60tnj42tttB"
+  },
+  {
+    "__type__": "cc.MeshRenderer",
+    "_name": "Cube<ModelComponent>",
+    "_objFlags": 0,
+    "node": {
+      "__id__": 11
+    },
+    "_enabled": true,
+    "__prefab": null,
+    "_materials": [
+      {
+        "__uuid__": "d3c7820c-2a98-4429-8bc7-b8453bc9ac41",
+        "__expectedType__": "cc.Material"
+      }
+    ],
+    "_visFlags": 0,
+    "lightmapSettings": {
+      "__id__": 13
+    },
+    "_mesh": {
+      "__uuid__": "1263d74c-8167-4928-91a6-4e2672411f47@a804a",
+      "__expectedType__": "cc.Mesh"
+    },
+    "_shadowCastingMode": 0,
+    "_shadowReceivingMode": 1,
+    "_enableMorph": true,
+    "_id": "71JOMy8OJLWaQ950b4F5K2"
+  },
+  {
+    "__type__": "cc.ModelLightmapSettings",
+    "texture": null,
+    "uvParam": {
+      "__type__": "cc.Vec4",
+      "x": 0,
+      "y": 0,
+      "z": 0,
+      "w": 0
+    },
+    "_bakeable": false,
+    "_castShadow": false,
+    "_receiveShadow": false,
+    "_recieveShadow": false,
+    "_lightmapSize": 64
+  },
+  {
+    "__type__": "cc.Node",
+    "_name": "White",
+    "_objFlags": 0,
+    "_parent": {
+      "__id__": 7
+    },
+    "_children": [],
+    "_active": true,
+    "_components": [
+      {
+        "__id__": 15
+      }
+    ],
+    "_prefab": null,
+    "_lpos": {
+      "__type__": "cc.Vec3",
+      "x": 30,
+      "y": 0,
+      "z": 0
+    },
+    "_lrot": {
+      "__type__": "cc.Quat",
+      "x": 0,
+      "y": 0,
+      "z": 0,
+      "w": 1
+    },
+    "_lscale": {
+      "__type__": "cc.Vec3",
+      "x": 10,
+      "y": 10,
+      "z": 10
+    },
+    "_layer": 1073741824,
+    "_euler": {
+      "__type__": "cc.Vec3",
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "_id": "afyFe9JzpEapdgWdMIMdXb"
+  },
+  {
+    "__type__": "cc.MeshRenderer",
+    "_name": "Cube<ModelComponent>",
+    "_objFlags": 0,
+    "node": {
+      "__id__": 14
+    },
+    "_enabled": true,
+    "__prefab": null,
+    "_materials": [
+      {
+        "__uuid__": "d3c7820c-2a98-4429-8bc7-b8453bc9ac41",
+        "__expectedType__": "cc.Material"
+      }
+    ],
+    "_visFlags": 0,
+    "lightmapSettings": {
+      "__id__": 16
+    },
+    "_mesh": {
+      "__uuid__": "1263d74c-8167-4928-91a6-4e2672411f47@a804a",
+      "__expectedType__": "cc.Mesh"
+    },
+    "_shadowCastingMode": 0,
+    "_shadowReceivingMode": 1,
+    "_enableMorph": true,
+    "_id": "1a9GoXK3tHvYzFawzMVZn7"
+  },
+  {
+    "__type__": "cc.ModelLightmapSettings",
+    "texture": null,
+    "uvParam": {
+      "__type__": "cc.Vec4",
+      "x": 0,
+      "y": 0,
+      "z": 0,
+      "w": 0
+    },
+    "_bakeable": false,
+    "_castShadow": false,
+    "_receiveShadow": false,
+    "_recieveShadow": false,
+    "_lightmapSize": 64
+  },
+  {
+    "__type__": "cc.Node",
+    "_name": "WhiteFromCanvas",
+    "_objFlags": 0,
+    "_parent": {
+      "__id__": 7
+    },
+    "_children": [],
+    "_active": true,
+    "_components": [
+      {
+        "__id__": 18
+      }
+    ],
+    "_prefab": null,
+    "_lpos": {
+      "__type__": "cc.Vec3",
+      "x": 45,
+      "y": 0,
+      "z": 0
+    },
+    "_lrot": {
+      "__type__": "cc.Quat",
+      "x": 0,
+      "y": 0,
+      "z": 0,
+      "w": 1
+    },
+    "_lscale": {
+      "__type__": "cc.Vec3",
+      "x": 10,
+      "y": 10,
+      "z": 10
+    },
+    "_layer": 1073741824,
+    "_euler": {
+      "__type__": "cc.Vec3",
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "_id": "a8I+tY02BCtqeqbHL/LdpF"
+  },
+  {
+    "__type__": "cc.MeshRenderer",
+    "_name": "Cube<ModelComponent>",
+    "_objFlags": 0,
+    "node": {
+      "__id__": 17
+    },
+    "_enabled": true,
+    "__prefab": null,
+    "_materials": [
+      {
+        "__uuid__": "d3c7820c-2a98-4429-8bc7-b8453bc9ac41",
+        "__expectedType__": "cc.Material"
+      }
+    ],
+    "_visFlags": 0,
+    "lightmapSettings": {
+      "__id__": 19
+    },
+    "_mesh": {
+      "__uuid__": "1263d74c-8167-4928-91a6-4e2672411f47@a804a",
+      "__expectedType__": "cc.Mesh"
+    },
+    "_shadowCastingMode": 0,
+    "_shadowReceivingMode": 1,
+    "_enableMorph": true,
+    "_id": "07iW0XoexGgqzagoYhzP8+"
+  },
+  {
+    "__type__": "cc.ModelLightmapSettings",
+    "texture": null,
+    "uvParam": {
+      "__type__": "cc.Vec4",
+      "x": 0,
+      "y": 0,
+      "z": 0,
+      "w": 0
+    },
+    "_bakeable": false,
+    "_castShadow": false,
+    "_receiveShadow": false,
+    "_recieveShadow": false,
+    "_lightmapSize": 64
+  },
+  {
+    "__type__": "cc.Node",
+    "_name": "Grey",
+    "_objFlags": 0,
+    "_parent": {
+      "__id__": 7
+    },
+    "_children": [],
+    "_active": true,
+    "_components": [
+      {
+        "__id__": 21
+      }
+    ],
+    "_prefab": null,
+    "_lpos": {
+      "__type__": "cc.Vec3",
+      "x": 0,
+      "y": 0,
+      "z": 15
+    },
+    "_lrot": {
+      "__type__": "cc.Quat",
+      "x": 0,
+      "y": 0,
+      "z": 0,
+      "w": 1
+    },
+    "_lscale": {
+      "__type__": "cc.Vec3",
+      "x": 10,
+      "y": 10,
+      "z": 10
+    },
+    "_layer": 1073741824,
+    "_euler": {
+      "__type__": "cc.Vec3",
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "_id": "13Stk9CgJEXpdk5Xkxprug"
+  },
+  {
+    "__type__": "cc.MeshRenderer",
+    "_name": "Cube<ModelComponent>",
+    "_objFlags": 0,
+    "node": {
+      "__id__": 20
+    },
+    "_enabled": true,
+    "__prefab": null,
+    "_materials": [
+      {
+        "__uuid__": "d3c7820c-2a98-4429-8bc7-b8453bc9ac41",
+        "__expectedType__": "cc.Material"
+      }
+    ],
+    "_visFlags": 0,
+    "lightmapSettings": {
+      "__id__": 22
+    },
+    "_mesh": {
+      "__uuid__": "1263d74c-8167-4928-91a6-4e2672411f47@a804a",
+      "__expectedType__": "cc.Mesh"
+    },
+    "_shadowCastingMode": 0,
+    "_shadowReceivingMode": 1,
+    "_enableMorph": true,
+    "_id": "09/QvrT/dFyqwdZqIXCtNp"
+  },
+  {
+    "__type__": "cc.ModelLightmapSettings",
+    "texture": null,
+    "uvParam": {
+      "__type__": "cc.Vec4",
+      "x": 0,
+      "y": 0,
+      "z": 0,
+      "w": 0
+    },
+    "_bakeable": false,
+    "_castShadow": false,
+    "_receiveShadow": false,
+    "_recieveShadow": false,
+    "_lightmapSize": 64
+  },
+  {
+    "__type__": "cc.Node",
+    "_name": "GreyFromCanvas",
+    "_objFlags": 0,
+    "_parent": {
+      "__id__": 7
+    },
+    "_children": [],
+    "_active": true,
+    "_components": [
+      {
+        "__id__": 24
+      }
+    ],
+    "_prefab": null,
+    "_lpos": {
+      "__type__": "cc.Vec3",
+      "x": 15,
+      "y": 0,
+      "z": 15
+    },
+    "_lrot": {
+      "__type__": "cc.Quat",
+      "x": 0,
+      "y": 0,
+      "z": 0,
+      "w": 1
+    },
+    "_lscale": {
+      "__type__": "cc.Vec3",
+      "x": 10,
+      "y": 10,
+      "z": 10
+    },
+    "_layer": 1073741824,
+    "_euler": {
+      "__type__": "cc.Vec3",
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "_id": "764fR+KJxP4YvTOgy+U4Gl"
+  },
+  {
+    "__type__": "cc.MeshRenderer",
+    "_name": "Cube<ModelComponent>",
+    "_objFlags": 0,
+    "node": {
+      "__id__": 23
+    },
+    "_enabled": true,
+    "__prefab": null,
+    "_materials": [
+      {
+        "__uuid__": "d3c7820c-2a98-4429-8bc7-b8453bc9ac41",
+        "__expectedType__": "cc.Material"
+      }
+    ],
+    "_visFlags": 0,
+    "lightmapSettings": {
+      "__id__": 25
+    },
+    "_mesh": {
+      "__uuid__": "1263d74c-8167-4928-91a6-4e2672411f47@a804a",
+      "__expectedType__": "cc.Mesh"
+    },
+    "_shadowCastingMode": 0,
+    "_shadowReceivingMode": 1,
+    "_enableMorph": true,
+    "_id": "aeMDHpP31BJa4F6hnr5abV"
+  },
+  {
+    "__type__": "cc.ModelLightmapSettings",
+    "texture": null,
+    "uvParam": {
+      "__type__": "cc.Vec4",
+      "x": 0,
+      "y": 0,
+      "z": 0,
+      "w": 0
+    },
+    "_bakeable": false,
+    "_castShadow": false,
+    "_receiveShadow": false,
+    "_recieveShadow": false,
+    "_lightmapSize": 64
+  },
+  {
+    "__type__": "cc.Node",
+    "_name": "Empty",
+    "_objFlags": 0,
+    "_parent": {
+      "__id__": 7
+    },
+    "_children": [],
+    "_active": true,
+    "_components": [
+      {
+        "__id__": 27
+      }
+    ],
+    "_prefab": null,
+    "_lpos": {
+      "__type__": "cc.Vec3",
+      "x": 30,
+      "y": 0,
+      "z": 15
+    },
+    "_lrot": {
+      "__type__": "cc.Quat",
+      "x": 0,
+      "y": 0,
+      "z": 0,
+      "w": 1
+    },
+    "_lscale": {
+      "__type__": "cc.Vec3",
+      "x": 10,
+      "y": 10,
+      "z": 10
+    },
+    "_layer": 1073741824,
+    "_euler": {
+      "__type__": "cc.Vec3",
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "_id": "40TBlulXRJFZFlrS2ILZdK"
+  },
+  {
+    "__type__": "cc.MeshRenderer",
+    "_name": "Cube<ModelComponent>",
+    "_objFlags": 0,
+    "node": {
+      "__id__": 26
+    },
+    "_enabled": true,
+    "__prefab": null,
+    "_materials": [
+      {
+        "__uuid__": "d3c7820c-2a98-4429-8bc7-b8453bc9ac41",
+        "__expectedType__": "cc.Material"
+      }
+    ],
+    "_visFlags": 0,
+    "lightmapSettings": {
+      "__id__": 28
+    },
+    "_mesh": {
+      "__uuid__": "1263d74c-8167-4928-91a6-4e2672411f47@a804a",
+      "__expectedType__": "cc.Mesh"
+    },
+    "_shadowCastingMode": 0,
+    "_shadowReceivingMode": 1,
+    "_enableMorph": true,
+    "_id": "18+oUIvSxGYIEGzAhPbNDW"
+  },
+  {
+    "__type__": "cc.ModelLightmapSettings",
+    "texture": null,
+    "uvParam": {
+      "__type__": "cc.Vec4",
+      "x": 0,
+      "y": 0,
+      "z": 0,
+      "w": 0
+    },
+    "_bakeable": false,
+    "_castShadow": false,
+    "_receiveShadow": false,
+    "_recieveShadow": false,
+    "_lightmapSize": 64
+  },
+  {
+    "__type__": "cc.Node",
+    "_name": "EmptyFromCanvas",
+    "_objFlags": 0,
+    "_parent": {
+      "__id__": 7
+    },
+    "_children": [],
+    "_active": true,
+    "_components": [
+      {
+        "__id__": 30
+      }
+    ],
+    "_prefab": null,
+    "_lpos": {
+      "__type__": "cc.Vec3",
+      "x": 45,
+      "y": 0,
+      "z": 15
+    },
+    "_lrot": {
+      "__type__": "cc.Quat",
+      "x": 0,
+      "y": 0,
+      "z": 0,
+      "w": 1
+    },
+    "_lscale": {
+      "__type__": "cc.Vec3",
+      "x": 10,
+      "y": 10,
+      "z": 10
+    },
+    "_layer": 1073741824,
+    "_euler": {
+      "__type__": "cc.Vec3",
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "_id": "44kx/4hwNF878RYfNFskaQ"
+  },
+  {
+    "__type__": "cc.MeshRenderer",
+    "_name": "Cube<ModelComponent>",
+    "_objFlags": 0,
+    "node": {
+      "__id__": 29
+    },
+    "_enabled": true,
+    "__prefab": null,
+    "_materials": [
+      {
+        "__uuid__": "d3c7820c-2a98-4429-8bc7-b8453bc9ac41",
+        "__expectedType__": "cc.Material"
+      }
+    ],
+    "_visFlags": 0,
+    "lightmapSettings": {
+      "__id__": 31
+    },
+    "_mesh": {
+      "__uuid__": "1263d74c-8167-4928-91a6-4e2672411f47@a804a",
+      "__expectedType__": "cc.Mesh"
+    },
+    "_shadowCastingMode": 0,
+    "_shadowReceivingMode": 1,
+    "_enableMorph": true,
+    "_id": "6cw/5ACIVLF6CjM+ihTLw3"
+  },
+  {
+    "__type__": "cc.ModelLightmapSettings",
+    "texture": null,
+    "uvParam": {
+      "__type__": "cc.Vec4",
+      "x": 0,
+      "y": 0,
+      "z": 0,
+      "w": 0
+    },
+    "_bakeable": false,
+    "_castShadow": false,
+    "_receiveShadow": false,
+    "_recieveShadow": false,
+    "_lightmapSize": 64
+  },
+  {
+    "__type__": "cc.Node",
+    "_name": "Normal",
+    "_objFlags": 0,
+    "_parent": {
+      "__id__": 7
+    },
+    "_children": [],
+    "_active": true,
+    "_components": [
+      {
+        "__id__": 33
+      }
+    ],
+    "_prefab": null,
+    "_lpos": {
+      "__type__": "cc.Vec3",
+      "x": 0,
+      "y": 0,
+      "z": 30
+    },
+    "_lrot": {
+      "__type__": "cc.Quat",
+      "x": 0,
+      "y": 0,
+      "z": 0,
+      "w": 1
+    },
+    "_lscale": {
+      "__type__": "cc.Vec3",
+      "x": 10,
+      "y": 10,
+      "z": 10
+    },
+    "_layer": 1073741824,
+    "_euler": {
+      "__type__": "cc.Vec3",
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "_id": "adsl+qQgFGZp3veqAw09fd"
+  },
+  {
+    "__type__": "cc.MeshRenderer",
+    "_name": "Cube<ModelComponent>",
+    "_objFlags": 0,
+    "node": {
+      "__id__": 32
+    },
+    "_enabled": true,
+    "__prefab": null,
+    "_materials": [
+      {
+        "__uuid__": "d3c7820c-2a98-4429-8bc7-b8453bc9ac41",
+        "__expectedType__": "cc.Material"
+      }
+    ],
+    "_visFlags": 0,
+    "lightmapSettings": {
+      "__id__": 34
+    },
+    "_mesh": {
+      "__uuid__": "1263d74c-8167-4928-91a6-4e2672411f47@a804a",
+      "__expectedType__": "cc.Mesh"
+    },
+    "_shadowCastingMode": 0,
+    "_shadowReceivingMode": 1,
+    "_enableMorph": true,
+    "_id": "9fTrIuZ05D3JUmxIWwPEn8"
+  },
+  {
+    "__type__": "cc.ModelLightmapSettings",
+    "texture": null,
+    "uvParam": {
+      "__type__": "cc.Vec4",
+      "x": 0,
+      "y": 0,
+      "z": 0,
+      "w": 0
+    },
+    "_bakeable": false,
+    "_castShadow": false,
+    "_receiveShadow": false,
+    "_recieveShadow": false,
+    "_lightmapSize": 64
+  },
+  {
+    "__type__": "cc.Node",
+    "_name": "NormalFromCanvas",
+    "_objFlags": 0,
+    "_parent": {
+      "__id__": 7
+    },
+    "_children": [],
+    "_active": true,
+    "_components": [
+      {
+        "__id__": 36
+      }
+    ],
+    "_prefab": null,
+    "_lpos": {
+      "__type__": "cc.Vec3",
+      "x": 15,
+      "y": 0,
+      "z": 30
+    },
+    "_lrot": {
+      "__type__": "cc.Quat",
+      "x": 0,
+      "y": 0,
+      "z": 0,
+      "w": 1
+    },
+    "_lscale": {
+      "__type__": "cc.Vec3",
+      "x": 10,
+      "y": 10,
+      "z": 10
+    },
+    "_layer": 1073741824,
+    "_euler": {
+      "__type__": "cc.Vec3",
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "_id": "bcOFXVc1tLKZD9nwKj6z++"
+  },
+  {
+    "__type__": "cc.MeshRenderer",
+    "_name": "Cube<ModelComponent>",
+    "_objFlags": 0,
+    "node": {
+      "__id__": 35
+    },
+    "_enabled": true,
+    "__prefab": null,
+    "_materials": [
+      {
+        "__uuid__": "d3c7820c-2a98-4429-8bc7-b8453bc9ac41",
+        "__expectedType__": "cc.Material"
+      }
+    ],
+    "_visFlags": 0,
+    "lightmapSettings": {
+      "__id__": 37
+    },
+    "_mesh": {
+      "__uuid__": "1263d74c-8167-4928-91a6-4e2672411f47@a804a",
+      "__expectedType__": "cc.Mesh"
+    },
+    "_shadowCastingMode": 0,
+    "_shadowReceivingMode": 1,
+    "_enableMorph": true,
+    "_id": "7fdvSXGplG7qLoWWMSTjK7"
+  },
+  {
+    "__type__": "cc.ModelLightmapSettings",
+    "texture": null,
+    "uvParam": {
+      "__type__": "cc.Vec4",
+      "x": 0,
+      "y": 0,
+      "z": 0,
+      "w": 0
+    },
+    "_bakeable": false,
+    "_castShadow": false,
+    "_receiveShadow": false,
+    "_recieveShadow": false,
+    "_lightmapSize": 64
+  },
+  {
+    "__type__": "cc.Node",
+    "_name": "Default",
+    "_objFlags": 0,
+    "_parent": {
+      "__id__": 7
+    },
+    "_children": [],
+    "_active": true,
+    "_components": [
+      {
+        "__id__": 39
+      }
+    ],
+    "_prefab": null,
+    "_lpos": {
+      "__type__": "cc.Vec3",
+      "x": 30,
+      "y": 0,
+      "z": 30
+    },
+    "_lrot": {
+      "__type__": "cc.Quat",
+      "x": 0,
+      "y": 0,
+      "z": 0,
+      "w": 1
+    },
+    "_lscale": {
+      "__type__": "cc.Vec3",
+      "x": 10,
+      "y": 10,
+      "z": 10
+    },
+    "_layer": 1073741824,
+    "_euler": {
+      "__type__": "cc.Vec3",
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "_id": "b11MMfwKVHDb8i3C8/x5z1"
+  },
+  {
+    "__type__": "cc.MeshRenderer",
+    "_name": "Cube<ModelComponent>",
+    "_objFlags": 0,
+    "node": {
+      "__id__": 38
+    },
+    "_enabled": true,
+    "__prefab": null,
+    "_materials": [
+      {
+        "__uuid__": "d3c7820c-2a98-4429-8bc7-b8453bc9ac41",
+        "__expectedType__": "cc.Material"
+      }
+    ],
+    "_visFlags": 0,
+    "lightmapSettings": {
+      "__id__": 40
+    },
+    "_mesh": {
+      "__uuid__": "1263d74c-8167-4928-91a6-4e2672411f47@a804a",
+      "__expectedType__": "cc.Mesh"
+    },
+    "_shadowCastingMode": 0,
+    "_shadowReceivingMode": 1,
+    "_enableMorph": true,
+    "_id": "6eFKDqQ5BAfrkYisrpq2JV"
+  },
+  {
+    "__type__": "cc.ModelLightmapSettings",
+    "texture": null,
+    "uvParam": {
+      "__type__": "cc.Vec4",
+      "x": 0,
+      "y": 0,
+      "z": 0,
+      "w": 0
+    },
+    "_bakeable": false,
+    "_castShadow": false,
+    "_receiveShadow": false,
+    "_recieveShadow": false,
+    "_lightmapSize": 64
+  },
+  {
+    "__type__": "cc.Node",
+    "_name": "DefaultFromCanvas",
+    "_objFlags": 0,
+    "_parent": {
+      "__id__": 7
+    },
+    "_children": [],
+    "_active": true,
+    "_components": [
+      {
+        "__id__": 42
+      }
+    ],
+    "_prefab": null,
+    "_lpos": {
+      "__type__": "cc.Vec3",
+      "x": 45,
+      "y": 0,
+      "z": 30
+    },
+    "_lrot": {
+      "__type__": "cc.Quat",
+      "x": 0,
+      "y": 0,
+      "z": 0,
+      "w": 1
+    },
+    "_lscale": {
+      "__type__": "cc.Vec3",
+      "x": 10,
+      "y": 10,
+      "z": 10
+    },
+    "_layer": 1073741824,
+    "_euler": {
+      "__type__": "cc.Vec3",
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "_id": "74klJiRYZME4kwrRDlNs/G"
+  },
+  {
+    "__type__": "cc.MeshRenderer",
+    "_name": "Cube<ModelComponent>",
+    "_objFlags": 0,
+    "node": {
+      "__id__": 41
+    },
+    "_enabled": true,
+    "__prefab": null,
+    "_materials": [
+      {
+        "__uuid__": "d3c7820c-2a98-4429-8bc7-b8453bc9ac41",
+        "__expectedType__": "cc.Material"
+      }
+    ],
+    "_visFlags": 0,
+    "lightmapSettings": {
+      "__id__": 43
+    },
+    "_mesh": {
+      "__uuid__": "1263d74c-8167-4928-91a6-4e2672411f47@a804a",
+      "__expectedType__": "cc.Mesh"
+    },
+    "_shadowCastingMode": 0,
+    "_shadowReceivingMode": 1,
+    "_enableMorph": true,
+    "_id": "17dqEgijNDQoW0WYYK16qe"
+  },
+  {
+    "__type__": "cc.ModelLightmapSettings",
+    "texture": null,
+    "uvParam": {
+      "__type__": "cc.Vec4",
+      "x": 0,
+      "y": 0,
+      "z": 0,
+      "w": 0
+    },
+    "_bakeable": false,
+    "_castShadow": false,
+    "_receiveShadow": false,
+    "_recieveShadow": false,
+    "_lightmapSize": 64
+  },
+  {
+    "__type__": "688f9YT1YFPCaX2+wgtZIv8",
+    "_name": "",
+    "_objFlags": 0,
+    "node": {
+      "__id__": 7
+    },
+    "_enabled": true,
+    "__prefab": null,
+    "nodeBlack": {
+      "__id__": 8
+    },
+    "nodeWhite": {
+      "__id__": 14
+    },
+    "nodeGrey": {
+      "__id__": 20
+    },
+    "nodeEmpty": {
+      "__id__": 26
+    },
+    "nodeNormal": {
+      "__id__": 32
+    },
+    "nodeDefault": {
+      "__id__": 38
+    },
+    "nodeBlack1": {
+      "__id__": 11
+    },
+    "nodeWhite1": {
+      "__id__": 17
+    },
+    "nodeGrey1": {
+      "__id__": 23
+    },
+    "nodeEmpty1": {
+      "__id__": 29
+    },
+    "nodeNormal1": {
+      "__id__": 35
+    },
+    "nodeDefault1": {
+      "__id__": 41
+    },
+    "_id": "4br6AOpEJJBrfjWOtjHl5p"
+  },
+  {
+    "__type__": "cc.SceneGlobals",
+    "ambient": {
+      "__id__": 46
+    },
+    "shadows": {
+      "__id__": 47
+    },
+    "_skybox": {
+      "__id__": 48
+    },
+    "fog": {
+      "__id__": 49
+    },
+    "octree": {
+      "__id__": 50
+    }
+  },
+  {
+    "__type__": "cc.AmbientInfo",
+    "_skyColorHDR": {
+      "__type__": "cc.Vec4",
+      "x": 0.2,
+      "y": 0.5,
+      "z": 0.8,
+      "w": 0.520833125
+    },
+    "_skyColor": {
+      "__type__": "cc.Vec4",
+      "x": 0.2,
+      "y": 0.5,
+      "z": 0.8,
+      "w": 0.520833125
+    },
+    "_skyIllumHDR": 20000,
+    "_skyIllum": 20000,
+    "_groundAlbedoHDR": {
+      "__type__": "cc.Vec4",
+      "x": 0.2,
+      "y": 0.2,
+      "z": 0.2,
+      "w": 1
+    },
+    "_groundAlbedo": {
+      "__type__": "cc.Vec4",
+      "x": 0.2,
+      "y": 0.2,
+      "z": 0.2,
+      "w": 1
+    },
+    "_skyColorLDR": {
+      "__type__": "cc.Vec4",
+      "x": 0.2,
+      "y": 0.5,
+      "z": 0.8,
+      "w": 0.5208
+    },
+    "_skyIllumLDR": 0.5208,
+    "_groundAlbedoLDR": {
+      "__type__": "cc.Vec4",
+      "x": 0.2,
+      "y": 0.2,
+      "z": 0.2,
+      "w": 1
+    }
+  },
+  {
+    "__type__": "cc.ShadowsInfo",
+    "_type": 0,
+    "_enabled": false,
+    "_normal": {
+      "__type__": "cc.Vec3",
+      "x": 0,
+      "y": 1,
+      "z": 0
+    },
+    "_distance": 0,
+    "_shadowColor": {
+      "__type__": "cc.Color",
+      "r": 76,
+      "g": 76,
+      "b": 76,
+      "a": 255
+    },
+    "_firstSetCSM": false,
+    "_fixedArea": false,
+    "_pcf": 0,
+    "_bias": 0.00001,
+    "_normalBias": 0,
+    "_near": 0.1,
+    "_far": 10,
+    "_shadowDistance": 100,
+    "_invisibleOcclusionRange": 200,
+    "_orthoSize": 5,
+    "_maxReceived": 4,
+    "_size": {
+      "__type__": "cc.Vec2",
+      "x": 512,
+      "y": 512
+    },
+    "_saturation": 0.75
+  },
+  {
+    "__type__": "cc.SkyboxInfo",
+    "_applyDiffuseMap": false,
+    "_envmapHDR": null,
+    "_envmap": null,
+    "_envmapLDR": null,
+    "_diffuseMapHDR": null,
+    "_diffuseMapLDR": null,
+    "_enabled": true,
+    "_useIBL": false,
+    "_useHDR": false
+  },
+  {
+    "__type__": "cc.FogInfo",
+    "_type": 0,
+    "_fogColor": {
+      "__type__": "cc.Color",
+      "r": 200,
+      "g": 200,
+      "b": 200,
+      "a": 255
+    },
+    "_enabled": false,
+    "_fogDensity": 0.3,
+    "_fogStart": 0.5,
+    "_fogEnd": 300,
+    "_fogAtten": 5,
+    "_fogTop": 1.5,
+    "_fogRange": 1.2,
+    "_accurate": false
+  },
+  {
+    "__type__": "cc.OctreeInfo",
+    "_enabled": false,
+    "_minPos": {
+      "__type__": "cc.Vec3",
+      "x": -1024,
+      "y": -1024,
+      "z": -1024
+    },
+    "_maxPos": {
+      "__type__": "cc.Vec3",
+      "x": 1024,
+      "y": 1024,
+      "z": 1024
+    },
+    "_depth": 8
+  }
+]

--- a/assets/cases/material/builtin-textures.scene
+++ b/assets/cases/material/builtin-textures.scene
@@ -1419,9 +1419,9 @@
       "x": 0.2,
       "y": 0.5,
       "z": 0.8,
-      "w": 0.5208
+      "w": 1
     },
-    "_skyIllumLDR": 0.5208,
+    "_skyIllumLDR": 1,
     "_groundAlbedoLDR": {
       "__type__": "cc.Vec4",
       "x": 0.2,

--- a/assets/cases/material/builtin-textures.scene.meta
+++ b/assets/cases/material/builtin-textures.scene.meta
@@ -1,0 +1,11 @@
+{
+  "ver": "1.1.35",
+  "importer": "scene",
+  "imported": true,
+  "uuid": "786100e2-d117-43f2-a3fe-ea5d0298cffe",
+  "files": [
+    ".json"
+  ],
+  "subMetas": {},
+  "userData": {}
+}


### PR DESCRIPTION
Re: [cocos-creator/3d-tasks#](https://github.com/cocos-creator/engine/pull/9841)

Changelog:
新增builtin-textures-test场景，用于对比测试使用arraybuffer生成的贴图与使用canvas生成的贴图。
如图，奇数列为arraybuffer，偶数列为canvas。
![2021-12-27_194833](https://user-images.githubusercontent.com/95199410/147469104-51fee51b-d50b-4796-ac6d-cd7eb41f50f9.png)

